### PR TITLE
Checkstyle rules applied to a couple of files

### DIFF
--- a/src/main/java/org/mutabilitydetector/findbugs/ThisPluginDetector.java
+++ b/src/main/java/org/mutabilitydetector/findbugs/ThisPluginDetector.java
@@ -29,10 +29,10 @@ import edu.umd.cs.findbugs.classfile.Global;
 import edu.umd.cs.findbugs.classfile.IClassPath;
 
 public class ThisPluginDetector implements Detector {
-    private static final String loggingLabel = MutabilityDetectorFindBugsPlugin.class.getSimpleName();
+    private static final String LOGGING_LABEL = MutabilityDetectorFindBugsPlugin.class.getSimpleName();
     
     static {
-        System.out.printf("Registered plugin detector [%s]%n", loggingLabel);
+        System.out.format("Registered plugin detector [%s]%n", LOGGING_LABEL);
     }
     
     private final BugReporter bugReporter;
@@ -96,7 +96,7 @@ public class ThisPluginDetector implements Detector {
                     URL toAdd = new File(classPathUrl).toURI().toURL();
                     urlList.add(toAdd);
                 } catch (MalformedURLException e) {
-                    System.err.printf("Classpath option %s is invalid.", classPathUrl);
+                    System.err.format("Classpath option %s is invalid.", classPathUrl);
                 }
             }
             return new URLClassLoader(urlList.toArray(new URL[urlList.size()]));


### PR DESCRIPTION
Major warnings fixed related to static final variable naming.

One warning ignored:
- Preserve Stack Trace in ThisPlugInDetector.java for throw a new exception in the below block:
  <code>
         } catch (InterruptedException e) {
              throw new ExceptionInInitializerError("Problem getting class path entries from FindBugs");
  </code>

(New exception is thrown in catch block, original stack trace may be lost)

What do you think of the above violation?
