### PR TITLE
Use specific FindBugs 2.0.1 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>findbugs</artifactId>
-      <version>[2.0.0, 2.0.1)</version>
+      <version>2.0.1</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
Previously I encountered errors of the form:

[ERROR] Failed to execute goal on project MutabilityDetector4FindBugs: Could not resolve dependencies for project org.mutabilitydetector:MutabilityDetector4FindBugs:jar:0.9.2-SNAPSHOT: Failed to collect dependencies for [org.mutabilitydetector:MutabilityDetector:jar:0.9 (compile), com.google.code.findbugs:findbugs:jar:[2.0.1,2.0.2) (compile), org.hamcrest:hamcrest-all:jar:1.1 (test), org.mockito:mockito-core:jar:[1.8.1,) (test), junit:junit-dep:jar:4.8 (test), com.youdevise:test-driven-detectors4findbugs:jar:1.0 (test)]: No versions available for com.google.code.findbugs:findbugs:jar:[2.0.1,2.0.2) within specified range -> [Help 1]
